### PR TITLE
modules/mdevd: add support for finit

### DIFF
--- a/modules/services/rsyslog/default.nix
+++ b/modules/services/rsyslog/default.nix
@@ -43,7 +43,7 @@ in
     finit.services.syslogd = {
       description = "system logging daemon";
       runlevels = "S0123456789";
-      conditions = "run/udevadm:5/success";
+      conditions = lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ] ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
       command = "${pkgs.rsyslog-light}/bin/rsyslogd -n -d -f ${configFile}";
     };
 

--- a/modules/services/sysklogd/default.nix
+++ b/modules/services/sysklogd/default.nix
@@ -14,7 +14,7 @@ in
     finit.services.syslogd = {
       description = "system logging daemon";
       runlevels = "S0123456789";
-      conditions = "run/udevadm:5/success";
+      conditions = lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ] ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
       command = "${pkgs.sysklogd}/bin/syslogd -F";
     };
 


### PR DESCRIPTION
currently this doesn't boot into a graphical (`wayland`) environment because of `libinput`s dependency on `udev`