### PR TITLE
modules/i18n: set locale for PID 1 and in pam_env.conf

### DIFF
--- a/modules/boot/init.nix
+++ b/modules/boot/init.nix
@@ -40,10 +40,6 @@ in
 
   config = {
 
-    boot.kernelParams = [
-      "init=${cfg.init.script}"
-    ];
-
     boot.init.script = pkgs.writeScript "init" ''
       #!${pkgs.runtimeShell}
 

--- a/modules/boot/init.nix
+++ b/modules/boot/init.nix
@@ -1,10 +1,10 @@
 { config, pkgs, lib, ... }:
 let
-  cfg = config.boot;
+  cfg = config.boot.init;
 
   # Sort and join the command-line of PID 1.
   pid1Argv =
-    (lib.textClosureList cfg.init.pid1Argv (builtins.attrNames cfg.init.pid1Argv))
+    (lib.textClosureList cfg.pid1.argv (builtins.attrNames cfg.pid1.argv))
     |> lib.flatten
     |> lib.escapeShellArgs;
 in
@@ -16,29 +16,43 @@ in
       readOnly = true;
     };
 
-    pid1Argv = lib.mkOption {
-      description = ''
-        The PID 1 command line as a closure-list.
-      '';
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options = {
-            deps = lib.mkOption {
-              type = with lib.types; listOf str;
-              default = [ ];
-              description = "List of argument groups that must preceded this one.";
+    pid1 = {
+      argv = lib.mkOption {
+        description = ''
+          The PID 1 command line as a closure-list.
+        '';
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              deps = lib.mkOption {
+                type = with lib.types; listOf str;
+                default = [ ];
+                description = "List of argument groups that must preceded this one.";
+              };
+              text = lib.mkOption {
+                type = with lib.types; uniq (either str (listOf (either str path)));
+                description = "Group of arguments for the pid1 command-line.";
+              };
             };
-            text = lib.mkOption {
-              type = with lib.types; uniq (either str (listOf (either str path)));
-              description = "Group of arguments for the pid1 command-line.";
-            };
-          };
-        }
-      );
+          }
+        );
+      };
+      env = lib.mkOption {
+        description = ''
+          Environment variables to start PID 1 with.
+        '';
+        type = with lib.types; attrsOf str;
+        default = { };
+      };
     };
   };
 
   config = {
+
+    # Set the environment via argv.
+    boot.init.pid1.argv.env.text = cfg.pid1.env
+      |> builtins.attrNames
+      |> lib.concatMap (key: [ "${pkgs.execline}/bin/export" key cfg.pid1.env.${key} ]);
 
     boot.init.script = pkgs.writeScript "init" ''
       #!${pkgs.runtimeShell}

--- a/modules/i18n/default.nix
+++ b/modules/i18n/default.nix
@@ -76,14 +76,15 @@
 
   config = {
 
+    # Boot with a locale set as early as practical.
+    boot.init.pid1.env = {
+      LANG = config.i18n.defaultLocale;
+      LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
+    } // config.i18n.extraLocaleSettings;
+
     environment.systemPackages =
       # We increase the priority a little, so that plain glibc in systemPackages can't win.
       lib.optional (config.i18n.supportedLocales != []) (lib.setPrio (-1) config.i18n.glibcLocales);
-
-    # environment.sessionVariables =
-    #   { LANG = config.i18n.defaultLocale;
-    #     LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
-    #   } // config.i18n.extraLocaleSettings;
 
     finit.environment = lib.mkIf (config.i18n.supportedLocales != []) {
       LOCALE_ARCHIVE = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
@@ -94,5 +95,11 @@
       LANG=${config.i18n.defaultLocale}
       ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "${n}=${v}") config.i18n.extraLocaleSettings)}
     '';
+
+    # Populate /etc/security/pam_env.conf.
+    security.pam.env = lib.mapAttrs (_: v: { override = v; }) ({
+      LANG = config.i18n.defaultLocale;
+      LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
+    } // config.i18n.extraLocaleSettings);
   };
 }


### PR DESCRIPTION
- Cleanup the configuration of init and PID 1.
- Add an option to generate `/etc/security/pam_env.conf`.
- Set locale on PID 1 so that it propagates into services.
- Set locale with PAM so that it propagates into logins.