### PR TITLE
modules/kernel: in-tree kernel modules are now in a separate derivati…

### DIFF
--- a/modules/boot/kernel.nix
+++ b/modules/boot/kernel.nix
@@ -192,7 +192,8 @@
   };
 
   config = lib.mkIf config.boot.kernel.enable {
-    system.modulesTree = [ config.boot.kernelPackages.kernel ] ++ config.boot.extraModulePackages;
+    # use split output for modules, when available
+    system.modulesTree = [ (config.boot.kernelPackages.kernel.modules or config.boot.kernelPackages.kernel) ] ++ config.boot.extraModulePackages;
 
     boot.kernelModules = [ "loop" "atkbd" ];
 


### PR DESCRIPTION
…on output

fallout after https://github.com/NixOS/nixpkgs/pull/423933

cc @ehmry you will hit this issue after updating nixpkgs, fix here