### PR TITLE
modules/pam: explicitly set pam_env conffile file path

### DIFF
--- a/modules/security/shadow/default.nix
+++ b/modules/security/shadow/default.nix
@@ -35,7 +35,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 # env (order 10100)
+        session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
         session required pam_loginuid.so # loginuid (order 10300)
         session required ${pkgs.linux-pam}/lib/security/pam_lastlog.so silent # lastlog (order 10700)
@@ -60,7 +60,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 # env (order 10100)
+        session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
         session optional pam_xauth.so systemuser=99 xauthpath=${pkgs.xorg.xauth}/bin/xauth # xauth (order 12100)
       '';
@@ -79,7 +79,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 # env (order 10100)
+        session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
       '';
     };

--- a/modules/security/sudo/default.nix
+++ b/modules/security/sudo/default.nix
@@ -17,7 +17,7 @@
       password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
       # Session management.
-      session required pam_env.so readenv=0 # env (order 10100)
+      session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
       session required pam_unix.so # unix (order 10200)
     '';
 

--- a/modules/services/atd/default.nix
+++ b/modules/services/atd/default.nix
@@ -55,7 +55,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 # env (order 10100)
+        session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
       '';
     };

--- a/modules/services/fcron/default.nix
+++ b/modules/services/fcron/default.nix
@@ -109,7 +109,7 @@ in
         # Warning : fcron has no way to prompt user for a password !
         auth		required	pam_permit.so
         #auth		required	pam_unix.so nullok
-        #auth		required	pam_env.so
+        #auth		required	pam_env.so conffile=/etc/security/pam_env.conf
         session		required	pam_permit.so
         #session		required	pam_unix.so
         session         required        pam_loginuid.so

--- a/modules/services/gdm/default.nix
+++ b/modules/services/gdm/default.nix
@@ -66,7 +66,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = gdm
-        session  required       pam_env.so readenv=0
+        session  required       pam_env.so conffile=/etc/security/pam_env.conf readenv=0
         session  optional       ${pkgs.elogind}/lib/security/pam_elogind.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so

--- a/modules/services/greetd/default.nix
+++ b/modules/services/greetd/default.nix
@@ -81,7 +81,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 # env (order 10100)
+        session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
         session required pam_loginuid.so # loginuid (order 10300)
       ''

--- a/modules/services/lemurs/default.nix
+++ b/modules/services/lemurs/default.nix
@@ -81,7 +81,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=1 debug # env (order 10100)
+        session required pam_env.so debug conffile=/etc/security/pam_env.conf readenv=1 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
         # https://github.com/coastalwhite/lemurs/issues/166
         session optional pam_loginuid.so # loginuid (order 10300)

--- a/modules/services/openssh/default.nix
+++ b/modules/services/openssh/default.nix
@@ -249,7 +249,7 @@ in
         password sufficient pam_unix.so nullok yescrypt debug # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 debug # env (order 10100)
+        session required pam_env.so debug conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so debug # unix (order 10200)
 
         ${lib.optionalString config.services.elogind.enable "session optional ${pkgs.elogind}/lib/security/pam_elogind.so"}

--- a/modules/services/polkit/default.nix
+++ b/modules/services/polkit/default.nix
@@ -97,7 +97,7 @@ in
         password sufficient pam_unix.so nullok yescrypt # unix (order 10200)
 
         # Session management.
-        session required pam_env.so readenv=0 # env (order 10100)
+        session required pam_env.so conffile=/etc/security/pam_env.conf readenv=0 # env (order 10100)
         session required pam_unix.so # unix (order 10200)
         session required pam_limits.so # conf=/nix/store/mibdlp1bmk4wl2qjk77i6fl1dg4kq6k6-limits.conf # limits (order 12200)
       '';

--- a/modules/services/sddm/default.nix
+++ b/modules/services/sddm/default.nix
@@ -121,7 +121,7 @@ in
         password required       pam_deny.so
 
         session  required       pam_succeed_if.so audit quiet_success user = sddm
-        session  required       pam_env.so readenv=0
+        session  required       pam_env.so conffile=/etc/security/pam_env.conf readenv=0
         session  optional       ${pkgs.elogind}/lib/security/pam_elogind.so
         session  optional       pam_keyinit.so force revoke
         session  optional       pam_permit.so


### PR DESCRIPTION
after updating to nixpkgs (revision `e50b14b3557037e5b4132db568b309c933d2fa3c`) i noticed `pam_env` wasn't sourcing `/etc/security/pam_env.conf` anymore

i don't know why, nothing seemed immediately obvious... there was a package bump, maybe that did it, though i'm not sure exactly why :man_shrugging: