### PR TITLE
modules/filesystems/btrfs: fix crypto module names

### DIFF
--- a/modules/filesystems/btrfs.nix
+++ b/modules/filesystems/btrfs.nix
@@ -49,9 +49,11 @@
       "crc32c"
     ]
     ++ lib.optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
-      "xxhash_generic"
-      "blake2b_generic"
-      "sha256_generic"
+      # The canonical names of these modules are not very stable, so use the algorithm names that the btrfs module expects.
+      # See: https://github.com/torvalds/linux/blob/v6.19-rc1/fs/btrfs/super.c#L2705-L2708
+      "xxhash64"
+      "sha256" # Should be baked into our kernel, just to be sure
+      "blake2b-256"
     ];
   };
 }


### PR DESCRIPTION
Use algorithm names that the btrfs kernel module expects (`xxhash64`, `sha256`, `blake2b-256`) instead of generic module names (`xxhash_generic`, `blake2b_generic`, `sha256_generic`), fixed some errors while building for me.

https://github.com/NixOS/nixpkgs/blob/b6a11bfa3ad664644bf6d1991229196d95837a4b/nixos/modules/tasks/filesystems/btrfs.nix#L91-L97