### PR TITLE
modules/greetd: prevent user session from restarting on updates

### DIFF
--- a/modules/services/greetd/default.nix
+++ b/modules/services/greetd/default.nix
@@ -7,8 +7,6 @@
 let
   cfg = config.services.greetd;
   format = pkgs.formats.toml { };
-
-  configFile = format.generate "greetd.toml" cfg.settings;
 in
 {
   options.services.greetd = {
@@ -40,6 +38,11 @@ in
       };
     };
 
+    environment.etc."greetd/config.toml".source = format.generate "greetd.toml" cfg.settings;
+    environment.systemPackages = [
+      pkgs.greetd
+    ];
+
     finit.services.greetd = {
       description = "greeter daemon";
       runlevels = "34";
@@ -48,7 +51,7 @@ in
       ]
       ++ lib.optionals config.services.elogind.enable [ "service/elogind/ready" ]
       ++ lib.optionals config.services.seatd.enable [ "service/seatd/ready" ];
-      command = "${pkgs.greetd}/bin/greetd --config ${configFile}";
+      command = "/run/current-system/sw/bin/greetd";
       cgroup.name = "user";
     };
 

--- a/modules/services/seatd/default.nix
+++ b/modules/services/seatd/default.nix
@@ -40,6 +40,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.seatd
+    ];
+
     users.groups = lib.optionalAttrs (cfg.group == "seat") {
       seat = { };
     };
@@ -50,7 +54,7 @@ in
       conditions = "service/syslogd/ready";
       notify = "s6";
       command =
-        "${pkgs.seatd.bin}/bin/seatd -n %n -u root -g ${cfg.group}"
+        "/run/current-system/sw/bin/seatd -n %n -u root -g ${cfg.group}"
         + lib.optionalString cfg.debug " -l debug";
     };
   };

--- a/modules/services/sysklogd/default.nix
+++ b/modules/services/sysklogd/default.nix
@@ -58,13 +58,17 @@ in
       cfg.package
     ];
 
+    environment.systemPackages = [
+      cfg.package
+    ];
+
     finit.services.syslogd = {
       description = "system logging daemon";
       runlevels = "S0123456789";
       conditions =
         lib.optionals config.services.udev.enable [ "run/udevadm:5/success" ]
         ++ lib.optionals config.services.mdevd.enable [ "run/coldplug/success" ];
-      command = "${cfg.package}/bin/syslogd -F";
+      command = "/run/current-system/sw/bin/syslogd -F";
       notify = "pid";
     };
 


### PR DESCRIPTION
currently updating `nixpkgs` and running `nixos-rebuild switch` will cause your graphical session to be killed because `finit` automatically restarts services which need to be restarted

this is great default behaviour... though not always desirable! by providing a stable string for `finit.services.<name>.command` we can avoid restarting services which will kill important services... at the cost of running out of date code

seems like this should possibly be a configurable option? more consideration needed. leaving this here as an example in the meantime.