### PR TITLE
feat(limine): add secure boot support

### DIFF
--- a/modules/programs/limine/default.nix
+++ b/modules/programs/limine/default.nix
@@ -239,44 +239,125 @@ in
         Force installation even if the safety checks fail, use absolutely only if necessary!
       '';
     };
+
+    secureBoot = {
+      enable = lib.mkEnableOption null // {
+        description = ''
+          Whether to sign the limine binary with {command}`sbctl`.
+
+          ::: {.note}
+          Requires pre-generated secure boot keys. See {option}`programs.limine.secureBoot.autoGenerateKeys`
+          and {option}`programs.limine.secureBoot.autoEnrollKeys` to automate key management.
+          :::
+        '';
+      };
+
+      autoGenerateKeys = lib.mkEnableOption null // {
+        description = ''
+          Generate keys automatically when none exists during bootloader installation.
+        '';
+      };
+
+      autoEnrollKeys = {
+        enable = lib.mkEnableOption null // {
+          description = ''
+            Enroll automatically generated keys.
+          '';
+        };
+        extraArgs = lib.mkOption {
+          default = [
+            "--microsoft"
+            "--firmware-builtin"
+          ];
+          type = lib.types.listOf lib.types.str;
+          description = ''
+            Extra arguments passed to {command}`sbctl`.
+          '';
+        };
+      };
+
+      sbctl = lib.mkPackageOption pkgs "sbctl" { };
+    };
   };
 
-  config = lib.mkIf cfg.enable {
-    assertions = [
-      {
-        assertion =
-          pkgs.stdenv.hostPlatform.isx86_64
-          || pkgs.stdenv.hostPlatform.isi686
-          || pkgs.stdenv.hostPlatform.isAarch64;
-        message = "Limine can only be installed on aarch64 & x86 platforms";
-      }
-      {
-        assertion = cfg.efiSupport || cfg.biosSupport;
-        message = "Both UEFI support and BIOS support for Limine are disabled, this will result in an unbootable system";
-      }
-    ];
-
-    # TODO: move these somewhere more appropriate
-    boot.supportedFilesystems.efivarfs.enable = lib.mkIf config.boot.loader.efi.canTouchEfiVariables true;
-    fileSystems."/sys/firmware/efi/efivars" = lib.mkIf config.boot.loader.efi.canTouchEfiVariables {
-      device = "efivarfs";
-      fsType = "efivarfs";
-      options = [
-        "defaults"
-        "nofail"
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion =
+            pkgs.stdenv.hostPlatform.isx86_64
+            || pkgs.stdenv.hostPlatform.isi686
+            || pkgs.stdenv.hostPlatform.isAarch64;
+          message = "Limine can only be installed on aarch64 & x86 platforms";
+        }
+        {
+          assertion = cfg.efiSupport || cfg.biosSupport;
+          message = "Both UEFI support and BIOS support for Limine are disabled, this will result in an unbootable system";
+        }
       ];
-    };
 
-    programs.limine.settings = {
-      graphics = true;
-      verbose = lib.mkIf cfg.debug true;
+      # TODO: move these somewhere more appropriate
+      boot.supportedFilesystems.efivarfs.enable = lib.mkIf config.boot.loader.efi.canTouchEfiVariables true;
+      fileSystems."/sys/firmware/efi/efivars" = lib.mkIf config.boot.loader.efi.canTouchEfiVariables {
+        device = "efivarfs";
+        fsType = "efivarfs";
+        options = [
+          "defaults"
+          "nofail"
+        ];
+      };
 
-      wallpaper = lib.mkDefault [ defaultWallpaper ];
-      backdrop = lib.mkDefault "2F302F";
-      wallpaper_style = lib.mkDefault "streched";
-    };
+      programs.limine.settings = {
+        graphics = true;
+        verbose = lib.mkIf cfg.debug true;
 
-    # this module supplies an implementation for `providers.bootloader`
-    providers.bootloader.backend = "limine";
-  };
+        wallpaper = lib.mkDefault [ defaultWallpaper ];
+        backdrop = lib.mkDefault "2F302F";
+        wallpaper_style = lib.mkDefault "streched";
+      };
+
+      # this module supplies an implementation for `providers.bootloader`
+      providers.bootloader.backend = "limine";
+    })
+    (lib.mkIf (cfg.enable && cfg.secureBoot.enable) {
+      assertions = [
+        {
+          assertion = cfg.enrollConfig;
+          message = "Disabling enrollConfig allows bypassing secure boot.";
+        }
+        {
+          assertion = cfg.validateChecksums;
+          message = "Disabling validateChecksums allows bypassing secure boot.";
+        }
+        {
+          assertion = cfg.settings.hash_mismatch_panic;
+          message = "Disabling hash_mismatch_panic allows bypassing secure boot.";
+        }
+        {
+          assertion = cfg.efiSupport;
+          message = "Secure boot is only supported on EFI systems.";
+        }
+        {
+          assertion = !cfg.settings.editor_enabled;
+          message = "Editor is unconditionally disabled by Limine.";
+        }
+      ];
+
+      programs.limine.enrollConfig = true;
+      programs.limine.validateChecksums = true;
+      programs.limine.settings.hash_mismatch_panic = true;
+      programs.limine.settings.editor_enabled = false;
+    })
+
+    (lib.mkIf (cfg.enable && cfg.secureBoot.enable && cfg.secureBoot.autoEnrollKeys.enable) {
+      assertions = [
+        {
+          assertion = cfg.secureBoot.autoGenerateKeys;
+          message = "autoEnrollKeys doesn't do anything without autoGenerateKeys.";
+        }
+      ];
+
+      programs.limine.secureBoot.autoGenerateKeys = true;
+    })
+  ];
 }

--- a/modules/programs/limine/limine-install.py
+++ b/modules/programs/limine/limine-install.py
@@ -44,6 +44,7 @@ libc = CDLL("libc.so.6")
 limine_install_dir: Optional[str] = None
 paths: Dict[str, bool] = {}
 
+
 def config(*path: str) -> Optional[Any]:
     result = install_config
     for component in path:
@@ -401,6 +402,10 @@ def install_bootloader() -> None:
             partition formatted as FAT.
         '''))
 
+    if config('secureBoot', 'enable') and not config('secureBoot', 'autoGenerateKeys') and not os.path.exists("/var/lib/sbctl"):
+        print("There are no sbctl secure boot keys present. Please generate some.")
+        sys.exit(1)
+
     if not os.path.exists(limine_install_dir):
         os.makedirs(limine_install_dir)
     else:
@@ -507,6 +512,42 @@ def install_bootloader() -> None:
             except:
                 print('error: failed to enroll limine config.', file=sys.stderr)
                 sys.exit(1)
+
+        if config('secureBoot', 'enable'):
+            sbctl = os.path.join(str(config('secureBoot', 'sbctl')), 'bin', 'sbctl')
+            if not os.path.exists("/var/lib/sbctl") and config('secureBoot', 'autoGenerateKeys'):
+                print('auto generating keys')
+                try:
+                    subprocess.run([sbctl, 'create-keys'])
+                except:
+                    print('error: failed to create keys', file=sys.stderr)
+                    sys.exit(1)
+                if config('secureBoot', 'autoEnrollKeys', 'enable'):
+                    try:
+                        command = [sbctl, 'enroll-keys']
+                        command.extend(config('secureBoot', 'autoEnrollKeys', 'extraArgs'))
+                        subprocess.run(command)
+                    except:
+                        print('error: failed to enroll keys', file=sys.stderr)
+                        sys.exit(1)
+
+            print('signing limine...')
+            try:
+                subprocess.run([sbctl, 'sign', dest_path])
+            except:
+                print('error: failed to sign limine', file=sys.stderr)
+                sys.exit(1)
+
+            import glob
+            fwupd_path = config('fwupdEfiPath')
+            if fwupd_path:
+                for efi in glob.glob(f'{fwupd_path}/libexec/fwupd/efi/*.efi'):
+                    print(f'signing fwupd: {os.path.basename(efi)}')
+                    try:
+                        subprocess.run([sbctl, 'sign', efi])
+                    except:
+                        print(f'error: failed to sign fwupd efi {efi}', file=sys.stderr)
+                        sys.exit(1)
 
         if not config('efiRemovable') and not config('canTouchEfiVariables'):
             print('warning: boot.loader.efi.canTouchEfiVariables is set to false while boot.loader.limine.efiInstallAsRemovable.\n  This may render the system unbootable.')

--- a/modules/programs/limine/providers.bootloader.nix
+++ b/modules/programs/limine/providers.bootloader.nix
@@ -20,6 +20,7 @@ let
         partitionIndex
         settings
         validateChecksums
+        secureBoot
         ;
 
       nixPath = config.services.nix-daemon.package;
@@ -31,6 +32,7 @@ let
       efiRemovable = cfg.efiInstallAsRemovable;
       maxGenerations = if cfg.maxGenerations == null then 0 else cfg.maxGenerations;
       hostArchitecture = pkgs.stdenv.hostPlatform.parsed.cpu;
+      fwupdEfiPath = lib.optionalAttrs config.services.fwupd.enable config.services.fwupd.package;
     }
   );
 in

--- a/modules/services/fwupd/default.nix
+++ b/modules/services/fwupd/default.nix
@@ -93,6 +93,9 @@ in
       conditions = "service/polkit/ready";
       log = true;
       nohup = true;
+      environment = lib.optionalAttrs (config.programs.limine.secureBoot.enable or false) {
+        FWUPD_EFIAPPDIR = "${cfg.package}/libexec/fwupd/efi";
+      };
     };
 
     finit.tmpfiles.rules = [


### PR DESCRIPTION
## Summary

- Add `programs.limine.secureBoot` options for signing the Limine bootloader with `sbctl`
- Support auto-generating and auto-enrolling secure boot keys
- Sign fwupd EFI binaries when secure boot is enabled
- Add assertions to enforce checksum validation, hash mismatch panic, and disabled editor when secure boot is on