### PR TITLE
Fix `services.xserver` unknown drivers section string substitution

### DIFF
--- a/modules/services/xserver/default.nix
+++ b/modules/services/xserver/default.nix
@@ -281,7 +281,7 @@ in
       name:
       let
         driver = lib.attrByPath [ name ] (
-          if pkgs.xorg ? ${"xf8-6video" + name} then { modules = [ pkgs.${"xf86-video" + name} ]; } else null
+          if pkgs ? ${".xf86-video-" + name} then { modules = [ pkgs.${"xf86-video-" + name} ]; } else null
         ) knownVideoDrivers;
       in
       lib.optional (driver != null) (

--- a/modules/services/xserver/default.nix
+++ b/modules/services/xserver/default.nix
@@ -281,7 +281,7 @@ in
       name:
       let
         driver = lib.attrByPath [ name ] (
-          if pkgs ? ${".xf86-video-" + name} then { modules = [ pkgs.${"xf86-video-" + name} ]; } else null
+          if pkgs ? ${"xf86-video-" + name} then { modules = [ pkgs.${"xf86-video-" + name} ]; } else null
         ) knownVideoDrivers;
       in
       lib.optional (driver != null) (


### PR DESCRIPTION
Looks like I missed some package string substitution in the `xserver` service; this PR rectifies this mistake and applies the correct string substitution. 